### PR TITLE
DI-2199: Remove solr node toleration.

### DIFF
--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -71,11 +71,7 @@ labels: {}
 annotations: {}
 nodeSelector: {}
 affinity: {}
-tolerations:
-  - effect: NoSchedule
-    key: solr
-    operator: Equal
-    value: "true"
+tolerations: []
 priorityClassName: ""
 sidecarContainers: []
 


### PR DESCRIPTION
Solr needs as much of the resources as it can use so we want to avoid
running this on those pods too. Also the solr-operator image isn't built
for arm to fails to schedule on those nodes if we are using graviton
instances.